### PR TITLE
Add Jungle4 EOS Nation API endpoint and net type

### DIFF
--- a/pyntelope/net.py
+++ b/pyntelope/net.py
@@ -286,6 +286,10 @@ class Jungle3Testnet(Net):
     host: pydantic.HttpUrl = "https://jungle3.eossweden.org"
 
 
+class Jungle4Testnet(Net):
+    host: pydantic.HttpUrl = "https://jungle4.api.eosnation.io"    
+
+
 class TelosMainnet(Net):
     host: pydantic.HttpUrl = "https://telos.caleos.io/"
 
@@ -319,6 +323,7 @@ __all__ = [
     "EosMainnet",
     "KylinTestnet",
     "Jungle3Testnet",
+    "Jungle4Testnet",
     "TelosMainnet",
     "TelosTestnet",
     "ProtonMainnet",


### PR DESCRIPTION
Seeing as how the EOS EVM has been added to Jungle4, and there is more testing being done on this network I figured it would be good to have this network type. Let me know if another endpoint is preferred. 

