### PR TITLE
Auto Build & Publish

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -1,4 +1,4 @@
-name: Main Workflow
+name: Automated Tests Workflow
 on: ['push', 'pull_request', 'workflow_dispatch']
 jobs:
   automated-tests:
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event"
+
       - run: echo "This job is now running on a ${{ runner.os }} server"
       - run: echo "The name of the branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
 
@@ -49,10 +50,9 @@ jobs:
           flake8 pyntelope/
 
       - name: Run docker image
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Run unit tests
         run: |
           source .venv/bin/activate
           pytest
-

--- a/.github/workflows/publish_workflow.yml
+++ b/.github/workflows/publish_workflow.yml
@@ -1,0 +1,36 @@
+name: Build and Publish Workflow
+on:
+  workflow_run:
+    workflows: ['Automated Tests Workflow']
+    types: ['completed']
+    branches: ['main']
+
+jobs:
+  build-and-publish-to-pypi:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Build
+        run: |
+          python3.9 -m venv .venv
+          source .venv/bin/activate
+          pip install poetry==1.8.5
+          poetry install --no-dev
+          poetry build
+
+      - name: Publish
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          source .venv/bin/activate
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry publish --repository=test-pypi --username=__token__ --password=$PYPI_TOKEN
+

--- a/.github/workflows/publish_workflow.yml
+++ b/.github/workflows/publish_workflow.yml
@@ -31,6 +31,5 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           source .venv/bin/activate
-          poetry config repositories.test-pypi https://test.pypi.org/legacy/
-          poetry publish --repository=test-pypi --username=__token__ --password=$PYPI_TOKEN
+          poetry publish --username=__token__ --password=$PYPI_TOKEN
 


### PR DESCRIPTION
Add a github action workflow to build and publish a package to pypi repo.
The workflow will only be triggered from a merge to the `main` branch. Also it will only run after all the tests are executed and are passing.
The publish process will fail if there there is no change in the package version number!